### PR TITLE
DM-48582: Fix skipping logic on analysis_tools import failure.

### DIFF
--- a/python/lsst/meas/extensions/multiprofit/analysis_tools.py
+++ b/python/lsst/meas/extensions/multiprofit/analysis_tools.py
@@ -37,11 +37,10 @@ from .pipetasks_fit import (
     component_names_default,
 )
 
-moments_sersic = MomentsConfig(xx="reff_x", yy="reff_y", xy="rho")
-
 
 if has_atools:
 
+    moments_sersic = MomentsConfig(xx="reff_x", yy="reff_y", xy="rho")
     class MultiProFitSizeMagnitudePlot(SizeMagnitudePlot):
         """A size-magnitude plot with default MultiProFit column names."""
 


### PR DESCRIPTION
An early version of the `analysis_tools` branch for this ticket included a circular import dependency that triggered the test-skipping logic here.  That revealed that the test-skipping logic wasn't actually complete - there was one line of unguarded code that depended on an import symbol, resulting in a failure, not skipped tests.