### PR TITLE
DM-49263: Remove now-unecessary includeScaleUncertainty override.

### DIFF
--- a/python/lsst/meas/extensions/multiprofit/utils.py
+++ b/python/lsst/meas/extensions/multiprofit/utils.py
@@ -127,7 +127,7 @@ def get_spanned_image(
                 variance=variance if get_sig_inv else None,
             )
     if calibrate:
-        maskedIm = exposure.photoCalib.calibrateImage(maskedIm, includeScaleUncertainty=False)
+        maskedIm = exposure.photoCalib.calibrateImage(maskedIm)
         if footprint is None:
             img = maskedIm.image.array
         else:


### PR DESCRIPTION
False is now the only behavior, and passing anything is deprecated.